### PR TITLE
Fix some docstring typos

### DIFF
--- a/pymathics/trepan/__main__.py
+++ b/pymathics/trepan/__main__.py
@@ -256,8 +256,9 @@ class TraceActivate(Builtin):
     >> TraceActivate[evaluation -> True]
      = ...
 
-    Show something similar to `TraceEvaluation' output:
+    Show something similar to 'TraceEvaluation' output:
     >> (x + 1)^2
+     = ...
 
     >> TraceActivate[evaluation -> False]
      = ...


### PR DESCRIPTION
Just a couple of typos that makes the doctests report a fail, and the documentation fails to compile properly.